### PR TITLE
Fixed loading relative images

### DIFF
--- a/Mordor/Eye-Of-Sauron.md
+++ b/Mordor/Eye-Of-Sauron.md
@@ -2,35 +2,8 @@ Here are some pictures of the Eye of Sauron!
 
 Just the photo.
 
-[[/Mordor/eye.jpg]]
+![](eye.jpg)
 
 With alt.
 
-[[/Mordor/eye.jpg|alt=Eye of Sauron]]
-
-With frame and caption.
-
-[[/Mordor/eye.jpg|frame|alt=Eye of Sauron]]
-
-Align left.
-
-[[/Mordor/eye.jpg|align=left]]
-
-Alight center.
-
-[[/Mordor/eye.jpg|align=center]]
-
-Alight right.
-
-[[/Mordor/eye.jpg|align=right]]
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas interdum velit eu justo rutrum vitae semper urna porttitor. Sed viverra bibendum tincidunt. Curabitur vel mi sed nisl vestibulum lobortis eu ac nisl. Morbi fringilla adipiscing felis. Mauris luctus interdum accumsan. Integer leo mauris, dapibus a sollicitudin non, varius non erat. Donec eu dictum orci. Morbi viverra eleifend felis, et adipiscing neque consequat a. Vestibulum accumsan ligula suscipit mi rhoncus ac gravida lectus tincidunt. Donec interdum, [[/Mordor/eye.jpg|float|frame|alt=FIRE FIRE FIRE]] lorem sed interdum molestie, est ipsum pharetra est, sit amet eleifend purus eros at ligula. Aliquam erat volutpat. Sed dignissim interdum ipsum, et pulvinar lectus faucibus et. Ut at lacus risus, non lobortis erat. Proin malesuada sagittis mauris, in posuere turpis tincidunt eu. Nunc accumsan, ligula ut rutrum aliquet, neque metus suscipit ligula, in aliquam augue velit vel orci. Aliquam diam lectus, posuere id faucibus sed, aliquam vel erat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas interdum velit eu justo rutrum vitae semper urna porttitor. Sed viverra bibendum tincidunt. Curabitur vel mi sed nisl vestibulum lobortis eu ac nisl. Morbi fringilla adipiscing felis. Mauris luctus interdum accumsan. Integer leo mauris, dapibus a sollicitudin non, varius non erat. Donec eu dictum orci. [[/Mordor/eye.jpg|float|align=right]] Morbi viverra eleifend felis, et adipiscing neque consequat a. Vestibulum accumsan ligula suscipit mi rhoncus ac gravida lectus tincidunt. Donec interdum, lorem sed interdum molestie, est ipsum pharetra est, sit amet eleifend purus eros at ligula. Aliquam erat volutpat. Sed dignissim interdum ipsum, et pulvinar lectus faucibus et. Ut at lacus risus, non lobortis erat. Proin malesuada sagittis mauris, in posuere turpis tincidunt eu. Nunc accumsan, ligula ut rutrum aliquet, neque metus suscipit ligula, in aliquam augue velit vel orci. Aliquam diam lectus, posuere id faucibus sed, aliquam vel erat.
-
-Smaller width.
-
-[[/Mordor/eye.jpg|width=100px]]
-
-Smaller height.
-
-[[/Mordor/eye.jpg|height=100px]]
-    
+![Eye of Sauron](eye.jpg)


### PR DESCRIPTION
Saw a SO question linking to this repo. I wanted to know if I could use relative paths in my readme. This repo was marked as the accepted answer on SO but then stopped working. See http://stackoverflow.com/questions/10045517/embedding-images-inside-a-github-wiki-gollum-repository

I don't know how to add frames in markdown or even do alignment. So I've deleted that code. Just wanted to update the relative path example, and notify you that these examples no longer work.

Thanks
